### PR TITLE
fix: update site title

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,7 +9,7 @@ import "../styles/scss/global.scss";
 		<meta name="viewport" content="width=device-width" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<meta name="generator" content={Astro.generator} />
-		<title>Astro Basics</title>
+		<title>Twin Cities OS</title>
 	</head>
 	<body>
 		<slot />


### PR DESCRIPTION
Replace "Astro Basics" with "Twin Cities OS"

Fixes https://github.com/twincities-os/twincitiesos.dev/issues/45

Before / After
![image](https://github.com/user-attachments/assets/f4442317-3ad5-44e3-bc72-c5191aa80bb5)